### PR TITLE
Add testing to GlobWindowsPaths

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -102,9 +103,13 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 }
 
 func createRun(opts *CreateOptions) error {
-	filenames, err := cmdutil.GlobWindowsPaths(opts.Filenames)
-	if err != nil {
-		return err
+	filenames := opts.Filenames
+	if runtime.GOOS == "windows" {
+		globbedNames, err := cmdutil.GlobWindowsPaths(opts.Filenames)
+		if err != nil {
+			return err
+		}
+		filenames = globbedNames
 	}
 
 	if len(filenames) == 0 {

--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"time"
 
@@ -37,9 +38,11 @@ type AssetForUpload struct {
 }
 
 func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
-	args, err = cmdutil.GlobWindowsPaths(args)
-	if err != nil {
-		return nil, err
+	if runtime.GOOS == "windows" {
+		args, err = cmdutil.GlobWindowsPaths(args)
+		if err != nil {
+			return nil, err
+		}
 	}
 	for _, arg := range args {
 		var label string

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -67,8 +67,10 @@ func GlobWindowsPaths(patterns []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", pattern, err)
 		}
-		if len(matches) != 0 {
+		if len(matches) > 0 {
 			expansions = append(expansions, matches...)
+		} else {
+			expansions = append(expansions, pattern)
 		}
 	}
 

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -3,7 +3,6 @@ package cmdutil
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -61,20 +60,17 @@ func NoArgsQuoteReminder(cmd *cobra.Command, args []string) error {
 }
 
 func GlobWindowsPaths(patterns []string) ([]string, error) {
-	if runtime.GOOS != "windows" {
-		return patterns, nil
-	}
-	var expansions []string
+	expansions := []string{}
+
 	for _, pattern := range patterns {
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %s", pattern, err)
+			return nil, fmt.Errorf("%s: %v", pattern, err)
 		}
-		if len(matches) > 0 {
+		if len(matches) != 0 {
 			expansions = append(expansions, matches...)
-		} else {
-			expansions = append(expansions, pattern)
 		}
 	}
+
 	return expansions, nil
 }

--- a/pkg/cmdutil/args_test.go
+++ b/pkg/cmdutil/args_test.go
@@ -156,18 +156,18 @@ func createTestDir(t *testing.T) (cleanupFn func()) {
 	}
 
 	// Make subdirectories
-	err = os.Mkdir(filepath.Join(rootDir, "subDir1"), 0o755)
+	err = os.Mkdir(filepath.Join(rootDir, "subDir1"), 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = os.Mkdir(filepath.Join(rootDir, "subDir2"), 0o755)
+	err = os.Mkdir(filepath.Join(rootDir, "subDir2"), 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Make Files
-	err = os.WriteFile(filepath.Join(rootDir, "rootFile.txt"), []byte(""), 0o644)
+	err = os.WriteFile(filepath.Join(rootDir, "rootFile.txt"), []byte(""), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmdutil/args_test.go
+++ b/pkg/cmdutil/args_test.go
@@ -71,9 +71,9 @@ func TestGlobWindowsPaths(t *testing.T) {
 			wantErr:  nil,
 		},
 		{
-			name:     "When no files match, it returns an empty expansions array",
+			name:     "When no files match, it returns an empty expansions array, it returns the unmatched patterns",
 			patterns: []string{"foo", "bar"},
-			wantOut:  []string{},
+			wantOut:  []string{"foo", "bar"},
 			wantErr:  nil,
 		},
 		{

--- a/pkg/cmdutil/args_test.go
+++ b/pkg/cmdutil/args_test.go
@@ -1,6 +1,13 @@
 package cmdutil
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestMinimumArgs(t *testing.T) {
 	tests := []struct {
@@ -47,4 +54,145 @@ func TestMinimumNs_with_error(t *testing.T) {
 			t.Errorf("Got: %v, Want: %v", got, test.WantMessage)
 		}
 	}
+}
+
+func TestGlobWindowsPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		os       string
+		patterns []string
+		wantOut  []string
+		wantErr  error
+	}{
+		{
+			name:     "When no patterns are passed, return an empty slice",
+			patterns: []string{},
+			wantOut:  []string{},
+			wantErr:  nil,
+		},
+		{
+			name:     "When no files match, it returns an empty expansions array",
+			patterns: []string{"foo", "bar"},
+			wantOut:  []string{},
+			wantErr:  nil,
+		},
+		{
+			name: "When a single pattern, '*.txt' is passed with one match, it returns that match",
+			patterns: []string{
+				"*.txt",
+			},
+			wantOut: []string{
+				"rootFile.txt",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "When a single pattern, '*/*.txt' is passed with multiple matches, it returns those matches",
+			patterns: []string{
+				"*/*.txt",
+			},
+			wantOut: []string{
+				"subDir1/subDir1_file.txt",
+				"subDir2/subDir2_file.txt",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "When multiple patterns, '*/*.txt' and '*/*.go', are passed with multiple matches, it returns those matches",
+			patterns: []string{
+				"*/*.txt",
+				"*/*.go",
+			},
+			wantOut: []string{
+				"subDir1/subDir1_file.txt",
+				"subDir2/subDir2_file.txt",
+				"subDir2/subDir2_file.go",
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanupFn := createTestDir(t)
+			defer cleanupFn()
+
+			got, err := GlobWindowsPaths(tt.patterns)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantOut, got)
+		})
+	}
+}
+
+// Creates a temporary directory with the structure below. Returns
+// a cleanup function that will remove the directory and all of its
+// contents. The cleanup function should be wrapped in a defer statement.
+//
+//	| root
+//	|-- rootFile.txt
+//	|-- subDir1
+//	|	|-- subDir1_file.txt
+//	|
+//	|-- subDir2
+//		|-- subDir2_file.go
+//		|-- subDir2_file.txt
+func createTestDir(t *testing.T) (cleanupFn func()) {
+	t.Helper()
+	// Make Directories
+	rootDir := t.TempDir()
+
+	// Move workspace to temporary directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Chdir(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make subdirectories
+	err = os.Mkdir(filepath.Join(rootDir, "subDir1"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(filepath.Join(rootDir, "subDir2"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make Files
+	err = os.WriteFile(filepath.Join(rootDir, "rootFile.txt"), []byte(""), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(rootDir, "subDir1", "subDir1_file.txt"), []byte(""), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(rootDir, "subDir2", "subDir2_file.go"), []byte(""), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(rootDir, "subDir2", "subDir2_file.txt"), []byte(""), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupFn = func() {
+		os.RemoveAll(rootDir)
+		err = os.Chdir(cwd)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return cleanupFn
 }


### PR DESCRIPTION
Here's my tests example. Note, I'm not actually testing that `filepath.Glob()` is doing what its supposed to be doing - I'm checking the function's interfaces of patterns in and matches out. These tests actually show that the [make](https://github.com/cli/cli/pull/10413/files#r1954304769) comment doesn't actually work, too, which is a bonus.