### PR TITLE
Separate partitioning from globbing in cmdutil/args package and consumers

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -105,10 +105,17 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 }
 
 func createRun(opts *CreateOptions) error {
-	filenames, err := cmdutil.GlobPaths(opts.Filenames, nil)
+
+	readFromStdInArg, filenames := cmdutil.Partition(opts.Filenames, func(f string) bool {
+		return f == "-"
+	})
+
+	filenames, err := cmdutil.GlobPaths(filenames)
 	if err != nil {
 		return err
 	}
+
+	filenames = append(filenames, readFromStdInArg...)
 
 	if len(filenames) == 0 {
 		filenames = []string{"-"}

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -225,9 +225,33 @@ func Test_createRun(t *testing.T) {
 			responseStatus: http.StatusOK,
 		},
 		{
-			name: "when both a file and the stdin '-' are provided, it matches on all the files",
+			name: "when both a file and the stdin '-' are provided, it matches on all the files passed in and stdin",
 			opts: &CreateOptions{
 				Filenames: []string{fixtureFile, "-"},
+			},
+			stdin:      "cool stdin content",
+			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
+			wantStderr: "- Creating gist with multiple files\n✓ Created secret gist fixture.txt\n",
+			wantErr:    false,
+			wantParams: map[string]interface{}{
+				"description": "",
+				"updated_at":  "0001-01-01T00:00:00Z",
+				"public":      false,
+				"files": map[string]interface{}{
+					"fixture.txt": map[string]interface{}{
+						"content": "{}",
+					},
+					"gistfile1.txt": map[string]interface{}{
+						"content": "cool stdin content",
+					},
+				},
+			},
+			responseStatus: http.StatusOK,
+		},
+		{
+			name: "when both a file and the stdin '-' are provided, but '-' is not the last argument, it matches on all the files provided and stdin",
+			opts: &CreateOptions{
+				Filenames: []string{"-", fixtureFile},
 			},
 			stdin:      "cool stdin content",
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -225,7 +225,7 @@ func Test_createRun(t *testing.T) {
 			responseStatus: http.StatusOK,
 		},
 		{
-			name: "multiple files",
+			name: "when both a file and the stdin '-' are provided, it matches on all the files",
 			opts: &CreateOptions{
 				Filenames: []string{fixtureFile, "-"},
 			},

--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -37,12 +37,17 @@ type AssetForUpload struct {
 }
 
 func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
-	args, err = cmdutil.GlobPaths(args, func(pattern string) bool {
-		return strings.Contains(pattern, "#")
+	labeledArgs, unlabeledArgs := cmdutil.Partition(args, func(arg string) bool {
+		return strings.Contains(arg, "#")
 	})
+
+	args, err = cmdutil.GlobPaths(unlabeledArgs)
 	if err != nil {
 		return nil, err
 	}
+
+	args = append(args, labeledArgs...)
+
 	for _, arg := range args {
 		var label string
 		fn := arg

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -59,22 +59,41 @@ func NoArgsQuoteReminder(cmd *cobra.Command, args []string) error {
 	return FlagErrorf("%s", errMsg)
 }
 
-func GlobPaths(patterns []string, exclude func(pattern string) bool) ([]string, error) {
+// Partition takes a slice of any type T and separates it into two slices
+// of the same type based on the provided predicate function. Any item
+// that returns true for the predicate will be included in the first slice
+// returned, and any item that returns false for the predicate will be
+// included in the second slice returned.
+func Partition[T any](slice []T, predicate func(T) bool) ([]T, []T) {
+	var matching, nonMatching []T
+	for _, item := range slice {
+		if predicate(item) {
+			matching = append(matching, item)
+		} else {
+			nonMatching = append(nonMatching, item)
+		}
+	}
+	return matching, nonMatching
+}
+
+// GlobPaths expands a list of file patterns into a list of file paths.
+// If no files match a pattern, that pattern will return an error.
+// If no pattern is passed, this returns an empty list and no error.
+//
+// For information on supported glob patterns, see
+// https://pkg.go.dev/path/filepath#Match
+func GlobPaths(patterns []string) ([]string, error) {
 	expansions := []string{}
 
 	for _, pattern := range patterns {
-		if pattern == "-" || (exclude != nil && exclude(pattern)) {
-			expansions = append(expansions, pattern)
-		} else {
-			matches, err := filepath.Glob(pattern)
-			if err != nil {
-				return nil, fmt.Errorf("%s: %v", pattern, err)
-			}
-			if len(matches) == 0 {
-				return []string{}, fmt.Errorf("no matches found for `%s`", pattern)
-			}
-			expansions = append(expansions, matches...)
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %v", pattern, err)
 		}
+		if len(matches) == 0 {
+			return []string{}, fmt.Errorf("no matches found for `%s`", pattern)
+		}
+		expansions = append(expansions, matches...)
 	}
 
 	return expansions, nil


### PR DESCRIPTION
## Changes

In the previous commit, I think that `GlobPaths` was overloaded, containing logic specific to command use-cases. This removes that functionality from `GlobPaths` and puts it back into the commands that have the special use-cases.

To do this, I've introduced a new `Partition` util in `cmdutil/args.go` that will separate a slice into two slices given a predicate. This functionality is leveraged by both the special use-cases described above to separate the command-specific syntax from the globable filepaths.

## Notes

This change doesn't preserve the order of arguments in `gh gist create`. Specifically, it'll move any passed in `"-"` to the end of the list of filepaths that are passed in as args. As far as I can tell, this shouldn't matter, and I've written a test to validate that hypothesis.

## Testing

The need for handling these special use-cases was indicated by failing unit tests. Thus, I'm using the tests as behavior validation in this PR.